### PR TITLE
Fix email lookup usage example in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Usage Examples
         person_twitter = fc_person.lookitup('patrickrm101', 'twitter')
 
         # look up a person via email
-        person_email = fc_person.lookitup('prussell@gmail.com')
+        person_email = fc_person.lookitup('prussell@gmail.com', 'email')
 
         return name, person_twitter, person_email
 


### PR DESCRIPTION
Thanks for writing this! Small typo in the README - the call to `fc_person.lookitup()` is missing `lookup_type`.
